### PR TITLE
Bug fix for empty list of ELIXIR permissions and introduce SPRING_CONFIG_URI environment variable 

### DIFF
--- a/src/main/java/eu/elixir/ega/ebi/dataedge/service/internal/RemoteFileServiceImpl.java
+++ b/src/main/java/eu/elixir/ega/ebi/dataedge/service/internal/RemoteFileServiceImpl.java
@@ -584,14 +584,10 @@ public class RemoteFileServiceImpl implements FileService {
                 permissions.add(next.getAuthority());
             }
         } else if (request!=null) { // ELIXIR User Case: Obtain Permmissions from X-Permissions Header
-            //String permissions_ = request.getHeader("X-Permissions");
             try {
                 List<String> permissions_ = (new VerifyMessage(request.getHeader("X-Permissions"))).getPermissions();
                 if (permissions_ != null && permissions_.size() > 0) {
-                    //StringTokenizer t = new StringTokenizer(permissions_, ",");
-                    //while (t!=null && t.hasMoreTokens()) {
-                    for (String ds:permissions) {
-                        //String ds = t.nextToken();
+                    for (String ds:permissions_) {
                         if (ds != null) {
                             permissions.add(ds);
                         }

--- a/src/main/resources/bootstrap.properties
+++ b/src/main/resources/bootstrap.properties
@@ -1,3 +1,3 @@
-spring.cloud.config.uri=http://pg-ega-pro-04.ebi.ac.uk:8888
+spring.cloud.config.uri=${SPRING_CONFIG_URI:http://pg-ega-pro-04.ebi.ac.uk:8888}
 #spring.cloud.config.uri=http://192.168.0.20:8888
 spring.application.name=dsedge


### PR DESCRIPTION
A list of ELIXIR permissions fetched from X-Permissions header was empty due list was appended with wrong variable (permissions, not permissions_). 
